### PR TITLE
feat: add prisma mysql setup and task api

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,43 +6,43 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 
 model User {
-  id                String            @id @default(cuid())
-  username          String            @unique
-  password          String
-  habits            Habit[]
-  tasks             Task[]
-  learningRoadmaps  LearningRoadmap[]
-  transactions      Transaction[]
-  createdAt         DateTime          @default(now())
-  updatedAt         DateTime          @updatedAt
+  id               String            @id @default(cuid())
+  username         String            @unique
+  password         String
+  habits           Habit[]
+  tasks            Task[]
+  learningRoadmaps LearningRoadmap[]
+  transactions     Transaction[]
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
 }
 
 model Habit {
-  id        String      @id @default(cuid())
+  id        String        @id @default(cuid())
   name      String
   category  HabitCategory
-  user      User        @relation(fields: [userId], references: [id])
+  user      User          @relation(fields: [userId], references: [id])
   userId    String
   logs      HabitLog[]
-  createdAt DateTime    @default(now())
-  updatedAt DateTime    @updatedAt
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
 }
 
 model HabitLog {
-  id              String  @id @default(cuid())
-  habit           Habit   @relation(fields: [habitId], references: [id], onDelete: Cascade)
-  habitId         String
-  date            DateTime @db.Date
-  completed       Boolean
-  journal         String?
-  reasonForMiss   String?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id            String   @id @default(cuid())
+  habit         Habit    @relation(fields: [habitId], references: [id], onDelete: Cascade)
+  habitId       String
+  date          DateTime @db.Date
+  completed     Boolean
+  journal       String?
+  reasonForMiss String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 }
 
 model Task {
@@ -68,13 +68,13 @@ model LearningRoadmap {
 }
 
 model LearningStep {
-  id          String           @id @default(cuid())
-  title       String
-  completed   Boolean          @default(false)
-  roadmap     LearningRoadmap  @relation(fields: [roadmapId], references: [id], onDelete: Cascade)
-  roadmapId   String
-  createdAt   DateTime         @default(now())
-  updatedAt   DateTime         @updatedAt
+  id        String          @id @default(cuid())
+  title     String
+  completed Boolean         @default(false)
+  roadmap   LearningRoadmap @relation(fields: [roadmapId], references: [id], onDelete: Cascade)
+  roadmapId String
+  createdAt DateTime        @default(now())
+  updatedAt DateTime        @updatedAt
 }
 
 model Transaction {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, HabitCategory, TransactionType } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
@@ -25,13 +25,13 @@ async function main() {
 
   // Seed Habits and Habit Logs
   const habitsData = [
-    { name: 'Jurnal Pagi', category: 'morning' },
-    { name: 'Baca Quran setelah Subuh', category: 'morning' },
-    { name: 'Sholat Sunnah Dzuhur', category: 'after_dhuhr' },
-    { name: 'Dzikir Sore', category: 'afternoon_evening' },
-    { name: 'Evaluasi tugas harian', category: 'afternoon_evening' },
-    { name: 'Baca buku sebelum tidur', category: 'sleep_prep' },
-    { name: 'Menilai Kualitas Tidur', category: 'sleep_prep' },
+    { name: 'Jurnal Pagi', category: HabitCategory.morning },
+    { name: 'Baca Quran setelah Subuh', category: HabitCategory.morning },
+    { name: 'Sholat Sunnah Dzuhur', category: HabitCategory.after_dhuhr },
+    { name: 'Dzikir Sore', category: HabitCategory.afternoon_evening },
+    { name: 'Evaluasi tugas harian', category: HabitCategory.afternoon_evening },
+    { name: 'Baca buku sebelum tidur', category: HabitCategory.sleep_prep },
+    { name: 'Menilai Kualitas Tidur', category: HabitCategory.sleep_prep },
   ];
 
   for (const habitData of habitsData) {
@@ -97,10 +97,10 @@ async function main() {
   
   // Seed Transactions
   const transactionsData = [
-    { date: new Date(new Date().setDate(new Date().getDate() - 2)), type: 'income', amount: 5000000, category: 'Gaji', description: 'Gaji bulanan' },
-    { date: new Date(new Date().setDate(new Date().getDate() - 2)), type: 'expense', amount: 50000, category: 'Makanan', description: 'Makan siang di kantor' },
-    { date: new Date(new Date().setDate(new Date().getDate() - 1)), type: 'expense', amount: 15000, category: 'Transportasi', description: 'Ojek online' },
-    { date: new Date(), type: 'expense', amount: 75000, category: 'Hiburan', description: 'Nonton film' },
+    { date: new Date(new Date().setDate(new Date().getDate() - 2)), type: TransactionType.income, amount: 5000000, category: 'Gaji', description: 'Gaji bulanan' },
+    { date: new Date(new Date().setDate(new Date().getDate() - 2)), type: TransactionType.expense, amount: 50000, category: 'Makanan', description: 'Makan siang di kantor' },
+    { date: new Date(new Date().setDate(new Date().getDate() - 1)), type: TransactionType.expense, amount: 15000, category: 'Transportasi', description: 'Ojek online' },
+    { date: new Date(), type: TransactionType.expense, amount: 75000, category: 'Hiburan', description: 'Nonton film' },
   ];
   
   for(const txData of transactionsData) {

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const data = await request.json()
+  const task = await prisma.task.update({
+    where: { id: params.id },
+    data,
+  })
+  return NextResponse.json(task)
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  await prisma.task.delete({ where: { id: params.id } })
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function GET() {
+  const user = await prisma.user.findFirst()
+  if (!user) return NextResponse.json([])
+  const tasks = await prisma.task.findMany({
+    where: { userId: user.id },
+    orderBy: { position: 'asc' },
+  })
+  return NextResponse.json(tasks)
+}
+
+export async function POST(request: NextRequest) {
+  const user = await prisma.user.findFirst()
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 400 })
+  }
+  const body = await request.json()
+  const count = await prisma.task.count({ where: { userId: user.id } })
+  const task = await prisma.task.create({
+    data: {
+      userId: user.id,
+      title: body.title,
+      description: body.description,
+      completed: false,
+      position: count,
+    },
+  })
+  return NextResponse.json(task, { status: 201 })
+}

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -28,6 +28,7 @@ type Task = {
   title: string;
   description?: string;
   completed: boolean;
+  position: number;
 };
 
 export default function TasksPage() {
@@ -50,6 +51,13 @@ export default function TasksPage() {
       setIsAuthenticated(true);
     }
   }, [router]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    fetch('/api/tasks')
+      .then(res => res.json())
+      .then((data: Task[]) => setTasks(data));
+  }, [isAuthenticated]);
   
   useEffect(() => {
     if (movedTaskId) {
@@ -59,60 +67,93 @@ export default function TasksPage() {
   }, [movedTaskId]);
 
 
-  const handleAddTask = (e: React.FormEvent) => {
+  const handleAddTask = async (e: React.FormEvent) => {
     e.preventDefault();
     if (newTaskTitle.trim() === '') return;
-    const task: Task = {
-      id: `task-${Date.now()}`,
-      title: newTaskTitle.trim(),
-      description: newTaskDescription.trim(),
-      completed: false,
-    };
-    setTasks(prev => [task, ...prev]);
-    setNewTaskTitle('');
-    setNewTaskDescription('');
-  };
-
-  const handleUpdateTask = () => {
-    if (!editingTask) return;
-    setTasks(prev =>
-      prev.map(task =>
-        task.id === editingTask.id ? editingTask : task
-      )
-    );
-    setEditingTask(null);
-  };
-
-  const handleToggleTask = (taskId: string) => {
-    setTasks(prev =>
-      prev.map(task =>
-        task.id === taskId ? { ...task, completed: !task.completed } : task
-      )
-    );
-  };
-
-  const handleDeleteTask = (taskId: string) => {
-    setTasks(prev => prev.filter(task => task.id !== taskId));
-    setEditingTask(null);
-  };
-
-  const handleMoveTask = (taskId: string, direction: 'up' | 'down') => {
-    setTasks(prev => {
-      const taskIndex = prev.findIndex(t => t.id === taskId);
-      if (taskIndex === -1) return prev;
-
-      const newTasks = [...prev];
-      const task = newTasks[taskIndex];
-      const swapIndex = direction === 'up' ? taskIndex - 1 : taskIndex + 1;
-
-      if (swapIndex < 0 || swapIndex >= newTasks.length) return prev;
-
-      newTasks[taskIndex] = newTasks[swapIndex];
-      newTasks[swapIndex] = task;
-
-      setMovedTaskId(taskId);
-      return newTasks;
+    const res = await fetch('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: newTaskTitle.trim(),
+        description: newTaskDescription.trim(),
+      }),
     });
+    if (res.ok) {
+      const created: Task = await res.json();
+      setTasks(prev => [...prev, created]);
+      setNewTaskTitle('');
+      setNewTaskDescription('');
+    }
+  };
+
+  const handleUpdateTask = async () => {
+    if (!editingTask) return;
+    const res = await fetch(`/api/tasks/${editingTask.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: editingTask.title,
+        description: editingTask.description,
+      }),
+    });
+    if (res.ok) {
+      const updated: Task = await res.json();
+      setTasks(prev =>
+        prev.map(task =>
+          task.id === updated.id ? updated : task
+        )
+      );
+      setEditingTask(null);
+    }
+  };
+
+  const handleToggleTask = async (taskId: string) => {
+    const current = tasks.find(t => t.id === taskId);
+    if (!current) return;
+    const res = await fetch(`/api/tasks/${taskId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ completed: !current.completed }),
+    });
+    if (res.ok) {
+      const updated: Task = await res.json();
+      setTasks(prev =>
+        prev.map(task =>
+          task.id === updated.id ? updated : task
+        )
+      );
+    }
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    const res = await fetch(`/api/tasks/${taskId}`, { method: 'DELETE' });
+    if (res.ok) {
+      setTasks(prev => prev.filter(task => task.id !== taskId));
+      setEditingTask(null);
+    }
+  };
+
+  const handleMoveTask = async (taskId: string, direction: 'up' | 'down') => {
+    const taskIndex = tasks.findIndex(t => t.id === taskId);
+    if (taskIndex === -1) return;
+
+    const newTasks = [...tasks];
+    const swapIndex = direction === 'up' ? taskIndex - 1 : taskIndex + 1;
+    if (swapIndex < 0 || swapIndex >= newTasks.length) return;
+
+    [newTasks[taskIndex], newTasks[swapIndex]] = [newTasks[swapIndex], newTasks[taskIndex]];
+    const withPositions = newTasks.map((t, idx) => ({ ...t, position: idx }));
+    setTasks(withPositions);
+    setMovedTaskId(taskId);
+    await Promise.all(
+      withPositions.map(t =>
+        fetch(`/api/tasks/${t.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ position: t.position }),
+        })
+      )
+    );
   };
   
   if (!isAuthenticated) {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined }
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
+  })
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+export default prisma


### PR DESCRIPTION
## Summary
- switch Prisma datasource to MySQL
- add shared Prisma client and REST API for tasks
- persist tasks via API in tasks page and seed enums properly

## Testing
- `DATABASE_URL='mysql://user:pass@localhost:3306/db' npx prisma validate`
- `DATABASE_URL='mysql://user:pass@localhost:3306/db' npx prisma generate`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive ESLint config prompt)*
- `npm run typecheck` *(fails: type error in src/components/ui/sidebar.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68b109fbcbe88325a929245feff1580b