### PR TITLE
feat: integrate prisma with mysql and habit api

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model HabitLog {
   reasonForMiss   String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+  @@unique([habitId, date])
 }
 
 model Task {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, HabitCategory, TransactionType } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
@@ -24,7 +24,7 @@ async function main() {
   console.log(`Created user with id: ${user.id}`)
 
   // Seed Habits and Habit Logs
-  const habitsData = [
+  const habitsData: { name: string; category: HabitCategory }[] = [
     { name: 'Jurnal Pagi', category: 'morning' },
     { name: 'Baca Quran setelah Subuh', category: 'morning' },
     { name: 'Sholat Sunnah Dzuhur', category: 'after_dhuhr' },
@@ -96,7 +96,7 @@ async function main() {
   console.log('Seeded learning roadmaps.');
   
   // Seed Transactions
-  const transactionsData = [
+  const transactionsData: { date: Date; type: TransactionType; amount: number; category: string; description: string }[] = [
     { date: new Date(new Date().setDate(new Date().getDate() - 2)), type: 'income', amount: 5000000, category: 'Gaji', description: 'Gaji bulanan' },
     { date: new Date(new Date().setDate(new Date().getDate() - 2)), type: 'expense', amount: 50000, category: 'Makanan', description: 'Makan siang di kantor' },
     { date: new Date(new Date().setDate(new Date().getDate() - 1)), type: 'expense', amount: 15000, category: 'Transportasi', description: 'Ojek online' },

--- a/src/app/api/habit-logs/[id]/route.ts
+++ b/src/app/api/habit-logs/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+interface Params {
+  params: { id: string };
+}
+
+export async function GET(_request: Request, { params }: Params) {
+  const log = await prisma.habitLog.findUnique({ where: { id: params.id } });
+  if (!log) {
+    return NextResponse.json(null, { status: 404 });
+  }
+  return NextResponse.json({
+    ...log,
+    date: log.date.toISOString().split('T')[0],
+  });
+}
+
+export async function PUT(request: Request, { params }: Params) {
+  const { completed, journal, reasonForMiss } = await request.json();
+  const log = await prisma.habitLog.update({
+    where: { id: params.id },
+    data: { completed, journal, reasonForMiss },
+  });
+  return NextResponse.json({
+    ...log,
+    date: log.date.toISOString().split('T')[0],
+  });
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  await prisma.habitLog.delete({ where: { id: params.id } });
+  return NextResponse.json(null, { status: 204 });
+}
+

--- a/src/app/api/habit-logs/[id]/route.ts
+++ b/src/app/api/habit-logs/[id]/route.ts
@@ -30,6 +30,6 @@ export async function PUT(request: Request, { params }: Params) {
 
 export async function DELETE(_request: Request, { params }: Params) {
   await prisma.habitLog.delete({ where: { id: params.id } });
-  return NextResponse.json(null, { status: 204 });
+  return new NextResponse(null, { status: 204 });
 }
 

--- a/src/app/api/habit-logs/[id]/route.ts
+++ b/src/app/api/habit-logs/[id]/route.ts
@@ -2,11 +2,12 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 export async function GET(_request: Request, { params }: Params) {
-  const log = await prisma.habitLog.findUnique({ where: { id: params.id } });
+  const { id } = await params;
+  const log = await prisma.habitLog.findUnique({ where: { id } });
   if (!log) {
     return NextResponse.json(null, { status: 404 });
   }
@@ -17,9 +18,10 @@ export async function GET(_request: Request, { params }: Params) {
 }
 
 export async function PUT(request: Request, { params }: Params) {
+  const { id } = await params;
   const { completed, journal, reasonForMiss } = await request.json();
   const log = await prisma.habitLog.update({
-    where: { id: params.id },
+    where: { id },
     data: { completed, journal, reasonForMiss },
   });
   return NextResponse.json({
@@ -29,7 +31,8 @@ export async function PUT(request: Request, { params }: Params) {
 }
 
 export async function DELETE(_request: Request, { params }: Params) {
-  await prisma.habitLog.delete({ where: { id: params.id } });
+  const { id } = await params;
+  await prisma.habitLog.delete({ where: { id } });
   return new NextResponse(null, { status: 204 });
 }
 

--- a/src/app/api/habit-logs/route.ts
+++ b/src/app/api/habit-logs/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const date = searchParams.get('date');
+  const user = await prisma.user.findFirst();
+  if (!user) {
+    return NextResponse.json([]);
+  }
+  const logs = await prisma.habitLog.findMany({
+    where: {
+      habit: { userId: user.id },
+      ...(date ? { date: new Date(date) } : {}),
+    },
+    orderBy: { date: 'asc' },
+  });
+  return NextResponse.json(
+    logs.map((log) => ({
+      ...log,
+      date: log.date.toISOString().split('T')[0],
+    }))
+  );
+}
+
+export async function POST(request: Request) {
+  const { habitId, date, completed, journal, reasonForMiss } = await request.json();
+  const log = await prisma.habitLog.upsert({
+    where: { habitId_date: { habitId, date: new Date(date) } },
+    update: { completed, journal, reasonForMiss },
+    create: { habitId, date: new Date(date), completed, journal, reasonForMiss },
+  });
+  return NextResponse.json({
+    ...log,
+    date: log.date.toISOString().split('T')[0],
+  }, { status: 201 });
+}
+

--- a/src/app/api/habits/[id]/route.ts
+++ b/src/app/api/habits/[id]/route.ts
@@ -18,5 +18,5 @@ export async function PUT(request: Request, { params }: Params) {
 export async function DELETE(_request: Request, { params }: Params) {
   const { id } = params;
   await prisma.habit.delete({ where: { id } });
-  return NextResponse.json(null, { status: 204 });
+  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/habits/[id]/route.ts
+++ b/src/app/api/habits/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+interface Params {
+  params: { id: string };
+}
+
+export async function PUT(request: Request, { params }: Params) {
+  const { id } = params;
+  const { name, category } = await request.json();
+  const habit = await prisma.habit.update({
+    where: { id },
+    data: { name, category },
+  });
+  return NextResponse.json(habit);
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const { id } = params;
+  await prisma.habit.delete({ where: { id } });
+  return NextResponse.json(null, { status: 204 });
+}

--- a/src/app/api/habits/[id]/route.ts
+++ b/src/app/api/habits/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 export async function PUT(request: Request, { params }: Params) {
-  const { id } = params;
+  const { id } = await params;
   const { name, category } = await request.json();
   const habit = await prisma.habit.update({
     where: { id },
@@ -16,7 +16,7 @@ export async function PUT(request: Request, { params }: Params) {
 }
 
 export async function DELETE(_request: Request, { params }: Params) {
-  const { id } = params;
+  const { id } = await params;
   await prisma.habit.delete({ where: { id } });
   return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/habits/route.ts
+++ b/src/app/api/habits/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET() {
+  const user = await prisma.user.findFirst();
+  if (!user) {
+    return NextResponse.json([]);
+  }
+  const habits = await prisma.habit.findMany({
+    where: { userId: user.id },
+    orderBy: { createdAt: 'asc' },
+  });
+  return NextResponse.json(habits);
+}
+
+export async function POST(request: Request) {
+  const { name, category } = await request.json();
+  const user = await prisma.user.findFirst();
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 400 });
+  }
+  const habit = await prisma.habit.create({
+    data: { name, category, userId: user.id },
+  });
+  return NextResponse.json(habit, { status: 201 });
+}

--- a/src/app/habits/page.tsx
+++ b/src/app/habits/page.tsx
@@ -1,7 +1,7 @@
 
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Fragment } from 'react';
 import { useRouter } from 'next/navigation';
 import { SidebarProvider, Sidebar, SidebarInset, SidebarContent, SidebarMenu, SidebarMenuItem, SidebarMenuButton, SidebarTrigger } from '@/components/ui/sidebar';
 import { LayoutDashboard, BarChart3, Settings, ListTodo, ChevronDown, Wallet, BookOpen, Plus, Trash2, Edit } from 'lucide-react';
@@ -261,9 +261,9 @@ export default function HabitsPage() {
                                         <CardContent>
                                             <ul className="space-y-3">
                                                 {groupedHabits[category as HabitCategory].map((habit, index) => (
-                                                   <>
+                                                   <Fragment key={habit.id}>
                                                    {index > 0 && <Separator />}
-                                                    <li key={habit.id} className="flex items-center justify-between py-2">
+                                                    <li className="flex items-center justify-between py-2">
                                                         <span className="font-medium text-lg">{habit.name}</span>
                                                         <div className="flex items-center gap-2">
                                                             <Button variant="outline" size="sm" onClick={() => setEditingHabit(habit)}>
@@ -292,7 +292,7 @@ export default function HabitsPage() {
                                                             </AlertDialog>
                                                         </div>
                                                     </li>
-                                                   </>
+                                                   </Fragment>
                                                 ))}
                                             </ul>
                                         </CardContent>

--- a/src/app/habits/page.tsx
+++ b/src/app/habits/page.tsx
@@ -49,54 +49,51 @@ export default function HabitsPage() {
         }
     }, [router]);
     
-    const handleAddHabit = (newHabitData: Omit<Habit, 'id'>) => {
-        fetch('/api/habits', {
+    const handleAddHabit = async (newHabitData: Omit<Habit, 'id'>) => {
+        const res = await fetch('/api/habits', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(newHabitData),
-        }).then(async res => {
-            if (res.ok) {
-                const habit = await res.json();
-                setHabits(prev => [...prev, habit]);
-                toast({
-                    title: "Kebiasaan Ditambahkan!",
-                    description: `"${habit.name}" telah ditambahkan.`,
-                });
-            }
         });
+        if (res.ok) {
+            const habit = await res.json();
+            setHabits(prev => [...prev, habit]);
+            toast({
+                title: "Kebiasaan Ditambahkan!",
+                description: `"${habit.name}" telah ditambahkan.`,
+            });
+        }
     };
 
-    const handleUpdateHabit = (updatedHabitData: Omit<Habit, 'id'>) => {
+    const handleUpdateHabit = async (updatedHabitData: Omit<Habit, 'id'>) => {
         if (!editingHabit) return;
-        fetch(`/api/habits/${editingHabit.id}`, {
+        const res = await fetch(`/api/habits/${editingHabit.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(updatedHabitData),
-        }).then(async res => {
-            if (res.ok) {
-                const habit = await res.json();
-                setHabits(prev => prev.map(h => h.id === habit.id ? habit : h));
-                toast({
-                    title: "Kebiasaan Diperbarui!",
-                    description: `"${habit.name}" telah berhasil diubah.`,
-                });
-                setEditingHabit(null);
-            }
         });
+        if (res.ok) {
+            const habit = await res.json();
+            setHabits(prev => prev.map(h => h.id === habit.id ? habit : h));
+            toast({
+                title: "Kebiasaan Diperbarui!",
+                description: `"${habit.name}" telah berhasil diubah.`,
+            });
+            setEditingHabit(null);
+        }
     };
 
-    const handleDeleteHabit = (habitId: string) => {
+    const handleDeleteHabit = async (habitId: string) => {
         const habitToDelete = habits.find(h => h.id === habitId);
-        fetch(`/api/habits/${habitId}`, { method: 'DELETE' }).then(res => {
-            if (res.ok) {
-                setHabits(prev => prev.filter(h => h.id !== habitId));
-                toast({
-                    title: "Kebiasaan Dihapus!",
-                    description: `"${habitToDelete?.name}" telah dihapus.`,
-                    variant: "destructive",
-                });
-            }
-        });
+        const res = await fetch(`/api/habits/${habitId}`, { method: 'DELETE' });
+        if (res.ok) {
+            setHabits(prev => prev.filter(h => h.id !== habitId));
+            toast({
+                title: "Kebiasaan Dihapus!",
+                description: `"${habitToDelete?.name}" telah dihapus.`,
+                variant: "destructive",
+            });
+        }
     };
     
     const groupedHabits = habits.reduce((acc, habit) => {

--- a/src/app/habits/page.tsx
+++ b/src/app/habits/page.tsx
@@ -37,15 +37,21 @@ export default function HabitsPage() {
     const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
     const [editingHabit, setEditingHabit] = useState<Habit | null>(null);
 
+    const loadHabits = async () => {
+        const res = await fetch('/api/habits', { cache: 'no-store' });
+        if (res.ok) {
+            const data = await res.json();
+            setHabits(data);
+        }
+    };
+
     useEffect(() => {
         const loggedIn = sessionStorage.getItem('isLoggedIn');
         if (loggedIn !== 'true') {
             router.push('/login');
         } else {
             setIsAuthenticated(true);
-            fetch('/api/habits')
-              .then(res => res.json())
-              .then(data => setHabits(data));
+            loadHabits();
         }
     }, [router]);
     
@@ -87,7 +93,7 @@ export default function HabitsPage() {
         const habitToDelete = habits.find(h => h.id === habitId);
         const res = await fetch(`/api/habits/${habitId}`, { method: 'DELETE' });
         if (res.ok) {
-            setHabits(prev => prev.filter(h => h.id !== habitId));
+            await loadHabits();
             toast({
                 title: "Kebiasaan Dihapus!",
                 description: `"${habitToDelete?.name}" telah dihapus.`,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,6 +46,7 @@ export default function Home() {
   const { toast } = useToast();
   const router = useRouter();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [viewMode, setViewMode] = useState<ViewMode>('focus');
   const [isActivityOpen, setIsActivityOpen] = useState(true);
   const [isFinanceOpen, setIsFinanceOpen] = useState(false);
@@ -63,13 +64,16 @@ export default function Home() {
 
   useEffect(() => {
     if (isAuthenticated) {
-      fetch('/api/habits')
-        .then((res) => res.json())
-        .then(setHabits);
+      setIsLoading(true);
       const today = new Date().toISOString().split('T')[0];
-      fetch(`/api/habit-logs?date=${today}`)
-        .then((res) => res.json())
-        .then(setLogs);
+      Promise.all([
+        fetch('/api/habits').then(res => res.json()),
+        fetch(`/api/habit-logs?date=${today}`).then(res => res.json())
+      ]).then(([habitsData, logsData]) => {
+        setHabits(habitsData);
+        setLogs(logsData);
+        setIsLoading(false);
+      });
     }
   }, [isAuthenticated]);
 
@@ -118,7 +122,7 @@ export default function Home() {
     }
   };
   
-  if (!isAuthenticated) {
+  if (!isAuthenticated || isLoading) {
     return (
       <div className="flex h-screen items-center justify-center bg-background">
         <p>Memuat...</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { initialHabits, initialLogs } from '@/lib/data';
 import type { Habit, HabitLog, HabitCategory } from '@/lib/types';
 import Header from '@/components/organisms/header';
 import HabitList from '@/components/organisms/habit-list';
@@ -59,90 +58,64 @@ export default function Home() {
       router.push('/login');
     } else {
       setIsAuthenticated(true);
-      // Load habits from session storage or use initial data
-      const storedHabits = sessionStorage.getItem('habits');
-      setHabits(storedHabits ? JSON.parse(storedHabits) : initialHabits);
-
-      // Load logs from session storage or use initial data
-      const storedLogs = sessionStorage.getItem('habitLogs');
-      setLogs(storedLogs ? JSON.parse(storedLogs) : initialLogs);
     }
   }, [router]);
 
   useEffect(() => {
     if (isAuthenticated) {
-        sessionStorage.setItem('habits', JSON.stringify(habits));
+      fetch('/api/habits')
+        .then((res) => res.json())
+        .then(setHabits);
+      const today = new Date().toISOString().split('T')[0];
+      fetch(`/api/habit-logs?date=${today}`)
+        .then((res) => res.json())
+        .then(setLogs);
     }
-  }, [habits, isAuthenticated]);
+  }, [isAuthenticated]);
 
-  useEffect(() => {
-    if (isAuthenticated) {
-        sessionStorage.setItem('habitLogs', JSON.stringify(logs));
-    }
-  }, [logs, isAuthenticated]);
-
-  // Listen for storage changes from other tabs
-  useEffect(() => {
-    const handleStorageChange = (event: StorageEvent) => {
-        if (event.key === 'habits' && event.newValue) {
-            setHabits(JSON.parse(event.newValue));
-        }
-        if (event.key === 'habitLogs' && event.newValue) {
-            setLogs(JSON.parse(event.newValue));
-        }
-    };
-
-    window.addEventListener('storage', handleStorageChange);
-    return () => {
-        window.removeEventListener('storage', handleStorageChange);
-    };
-  }, []);
-
-  const handleAddHabit = (newHabit: Omit<Habit, 'id'>) => {
-    const habitWithId = { ...newHabit, id: `habit-${Date.now()}` };
-    setHabits((prev) => [...prev, habitWithId]);
-    toast({
-      title: "Kebiasaan Ditambahkan!",
-      description: `"${newHabit.name}" telah ditambahkan ke daftar Anda.`,
+  const handleAddHabit = async (newHabit: Omit<Habit, 'id'>) => {
+    const res = await fetch('/api/habits', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newHabit),
     });
+    if (res.ok) {
+      const habit: Habit = await res.json();
+      setHabits((prev) => [...prev, habit]);
+      toast({
+        title: "Kebiasaan Ditambahkan!",
+        description: `"${habit.name}" telah ditambahkan ke daftar Anda.`,
+      });
+    }
   };
 
-  const handleLogHabit = (
+  const handleLogHabit = async (
     habitId: string,
     date: string,
     completed: boolean,
     details: { journal?: string; reasonForMiss?: string }
   ) => {
-    setLogs((prevLogs) => {
-      const existingLogIndex = prevLogs.findIndex(
-        (log) => log.habitId === habitId && log.date === date
-      );
-
-      if (existingLogIndex > -1) {
-        const updatedLogs = [...prevLogs];
-        const currentLog = updatedLogs[existingLogIndex];
-        updatedLogs[existingLogIndex] = {
-          ...currentLog,
-          completed,
-          journal: completed ? details.journal : currentLog.journal,
-          reasonForMiss: !completed ? details.reasonForMiss : currentLog.reasonForMiss,
-        };
-        return updatedLogs;
-      } else {
-        const newLog: HabitLog = {
-          id: `log-${Date.now()}`,
-          habitId,
-          date,
-          completed,
-          ...details,
-        };
-        return [...prevLogs, newLog];
-      }
+    const res = await fetch('/api/habit-logs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ habitId, date, completed, ...details }),
     });
-    toast({
-      title: "Log Diperbarui!",
-      description: `Progres Anda untuk hari ini telah disimpan.`,
-    });
+    if (res.ok) {
+      const log: HabitLog = await res.json();
+      setLogs((prevLogs) => {
+        const index = prevLogs.findIndex((l) => l.id === log.id);
+        if (index > -1) {
+          const updated = [...prevLogs];
+          updated[index] = log;
+          return updated;
+        }
+        return [...prevLogs, log];
+      });
+      toast({
+        title: "Log Diperbarui!",
+        description: `Progres Anda untuk hari ini telah disimpan.`,
+      });
+    }
   };
   
   if (!isAuthenticated) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ const CATEGORIES: { title: string; category: HabitCategory; startHour: number, e
   { title: 'Persiapan & Kualitas Tidur', category: 'sleep_prep', startHour: 22, endHour: 3 },
 ];
 
-const getCurrentCategory = (): HabitCategory | 'all' => {
+const getCurrentCategory = (): HabitCategory => {
     const currentHour = new Date().getHours();
     for (const cat of CATEGORIES) {
         if (cat.startHour <= cat.endHour) {

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -130,8 +130,13 @@ export default function ReportsPage() {
         return;
     }
 
-    const csvContent = "data:text/csv;charset=utf-8," 
-        + [Object.keys(dataToExport[0]), ...dataToExport.map(item => Object.values(item).map(val => `"${String(val).replace(/"/g, '""')}"`).join(","))].map(e => e.join(",")).join("\n");
+    const rows: string[][] = [
+        Object.keys(dataToExport[0]),
+        ...dataToExport.map(item =>
+            Object.values(item).map(val => `"${String(val).replace(/"/g, '""')}"`)
+        ),
+    ];
+    const csvContent = "data:text/csv;charset=utf-8," + rows.map(row => row.join(",")).join("\n");
 
     const encodedUri = encodeURI(csvContent);
     const link = document.createElement("a");

--- a/src/components/molecules/add-habit-form.tsx
+++ b/src/components/molecules/add-habit-form.tsx
@@ -31,7 +31,7 @@ const formSchema = z.object({
 });
 
 type AddHabitFormProps = {
-  onAddHabit: (habit: Omit<Habit, 'id'>) => void;
+  onAddHabit: (habit: Omit<Habit, 'id'>) => Promise<void>;
   setDialogOpen: (open: boolean) => void;
   initialData?: Habit;
 };
@@ -51,8 +51,8 @@ export default function AddHabitForm({ onAddHabit, setDialogOpen, initialData }:
     }
   }, [initialData, form]);
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
-    onAddHabit({
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await onAddHabit({
       name: values.name,
       category: values.category as HabitCategory,
     });

--- a/src/components/molecules/add-habit-form.tsx
+++ b/src/components/molecules/add-habit-form.tsx
@@ -23,7 +23,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import type { Habit, HabitCategory } from '@/lib/types';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
 
 const formSchema = z.object({
   name: z.string().min(3, 'Nama kebiasaan minimal 3 karakter.'),
@@ -44,6 +45,7 @@ export default function AddHabitForm({ onAddHabit, setDialogOpen, initialData }:
       category: initialData?.category || 'morning',
     },
   });
+  const [isSubmitting, setIsSubmitting] = useState(false);
   
   useEffect(() => {
     if (initialData) {
@@ -52,10 +54,12 @@ export default function AddHabitForm({ onAddHabit, setDialogOpen, initialData }:
   }, [initialData, form]);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
+    setIsSubmitting(true);
     await onAddHabit({
       name: values.name,
       category: values.category as HabitCategory,
     });
+    setIsSubmitting(false);
     form.reset();
     setDialogOpen(false);
   }
@@ -101,7 +105,8 @@ export default function AddHabitForm({ onAddHabit, setDialogOpen, initialData }:
             </FormItem>
           )}
         />
-        <Button type="submit" className="w-full h-11">
+        <Button type="submit" className="w-full h-11" disabled={isSubmitting}>
+          {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           {isEditing ? 'Simpan Perubahan' : 'Tambah Kebiasaan'}
         </Button>
       </form>

--- a/src/components/molecules/habit-logger.tsx
+++ b/src/components/molecules/habit-logger.tsx
@@ -15,7 +15,7 @@ import {
   DialogClose,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
-import { ThumbsDown, ThumbsUp, CheckCircle2, XCircle, PencilLine } from 'lucide-react';
+import { ThumbsDown, ThumbsUp, CheckCircle2, XCircle, PencilLine, Loader2 } from 'lucide-react';
 
 type HabitLoggerProps = {
   habitId: string;
@@ -42,6 +42,7 @@ export default function HabitLogger({
   onLogHabit,
 }: HabitLoggerProps) {
   const [dialogState, setDialogState] = useState<DialogState>({ open: false, type: null, text: '' });
+  const [isSaving, setIsSaving] = useState(false);
 
   const handleOpenDialog = (type: 'journal' | 'reason' | 'edit_journal' | 'edit_reason') => {
     let text = '';
@@ -53,13 +54,15 @@ export default function HabitLogger({
     setDialogState({ open: true, type, text });
   };
   
-  const handleSave = () => {
+  const handleSave = async () => {
     if (dialogState.type) {
+      setIsSaving(true);
       const completed = dialogState.type === 'journal' || dialogState.type === 'edit_journal';
-      const details = completed 
-        ? { journal: dialogState.text } 
+      const details = completed
+        ? { journal: dialogState.text }
         : { reasonForMiss: dialogState.text };
-      onLogHabit(habitId, date, completed, details);
+      await onLogHabit(habitId, date, completed, details);
+      setIsSaving(false);
     }
     setDialogState({ open: false, type: null, text: '' });
   };
@@ -108,7 +111,10 @@ export default function HabitLogger({
               <DialogClose asChild>
                 <Button type="button" variant="secondary">Batal</Button>
               </DialogClose>
-              <Button onClick={handleSave}>Simpan Perubahan</Button>
+              <Button onClick={handleSave} disabled={isSaving}>
+                {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Simpan Perubahan
+              </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
@@ -152,7 +158,10 @@ export default function HabitLogger({
               <DialogClose asChild>
                 <Button type="button" variant="secondary">Batal</Button>
               </DialogClose>
-              <Button onClick={handleSave}>Simpan</Button>
+              <Button onClick={handleSave} disabled={isSaving}>
+                {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Simpan
+              </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>

--- a/src/components/molecules/habit-logger.tsx
+++ b/src/components/molecules/habit-logger.tsx
@@ -15,6 +15,8 @@ import {
   DialogClose,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { ThumbsDown, ThumbsUp, CheckCircle2, XCircle, PencilLine, Loader2 } from 'lucide-react';
 
 type HabitLoggerProps = {
@@ -92,19 +94,33 @@ export default function HabitLogger({
         <Dialog open={dialogState.open && (dialogState.type === 'edit_journal' || dialogState.type === 'edit_reason')} onOpenChange={(open) => setDialogState(prev => ({ ...prev, open }))}>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>
-                {dialogState.type === 'edit_journal' ? 'Edit jurnalmu' : 'Edit alasanmu'}
-              </DialogTitle>
-              <DialogDescription>
-                {dialogState.type === 'edit_journal'
-                  ? 'Perbarui ceritamu tentang pencapaianmu hari ini.'
-                  : "Perbarui alasan mengapa kamu melewatkannya hari ini."}
-              </DialogDescription>
+              <DialogTitle>Edit log harian</DialogTitle>
+              <DialogDescription>Perbarui status dan catatan hari ini.</DialogDescription>
             </DialogHeader>
+            <RadioGroup
+              value={dialogState.type as 'edit_journal' | 'edit_reason'}
+              onValueChange={(value) =>
+                setDialogState((prev) => ({ ...prev, type: value as 'edit_journal' | 'edit_reason', text: '' }))
+              }
+              className="flex gap-4 mb-4"
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="edit_journal" id="edit-completed" />
+                <Label htmlFor="edit-completed">Selesai</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="edit_reason" id="edit-missed" />
+                <Label htmlFor="edit-missed">Terlewat</Label>
+              </div>
+            </RadioGroup>
             <Textarea
               value={dialogState.text}
               onChange={(e) => setDialogState(prev => ({ ...prev, text: e.target.value }))}
-              placeholder="Tuliskan catatanmu di sini..."
+              placeholder={
+                dialogState.type === 'edit_journal'
+                  ? 'Tuliskan catatanmu di sini...'
+                  : 'Tuliskan alasanmu di sini...'
+              }
               rows={4}
             />
             <DialogFooter>

--- a/src/components/organisms/header.tsx
+++ b/src/components/organisms/header.tsx
@@ -31,7 +31,7 @@ import {
 
 
 type HeaderProps = {
-  onAddHabit: (habit: Omit<Habit, 'id'>) => void;
+  onAddHabit: (habit: Omit<Habit, 'id'>) => Promise<void>;
 };
 
 export default function Header({ onAddHabit }: HeaderProps) {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -559,7 +559,7 @@ const SidebarMenuButton = React.forwardRef<
   ) => {
     const { isMobile, state } = useSidebar()
     const isLink = !!href
-    const Comp = asChild ? Slot : isLink ? NextLink : "button"
+    const Comp: any = asChild ? Slot : isLink ? NextLink : "button"
 
     const button = (
       <Comp

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma?: PrismaClient };
+
+const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export default prisma;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
-export type HabitCategory = 'morning' | 'after_dhuhr' | 'afternoon_evening' | 'sleep_prep' | 'all';
+export type HabitCategory = 'morning' | 'after_dhuhr' | 'afternoon_evening' | 'sleep_prep';
+export type HabitCategoryWithAll = HabitCategory | 'all';
 
 export type Habit = {
   id: string;


### PR DESCRIPTION
## Summary
- switch Prisma datasource to MySQL and add shared client
- add habit API routes and update habits page to use Prisma-backed CRUD
- refine enums and seed typing; fix CSV export and sidebar type issues

## Testing
- `npx prisma generate`
- `npm run typecheck`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68b12579131c8325bb198677d8e410ae