### PR TITLE
Allow editing habit log status in reports and fix async params

### DIFF
--- a/src/app/api/habit-logs/[id]/route.ts
+++ b/src/app/api/habit-logs/[id]/route.ts
@@ -2,11 +2,12 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 export async function GET(_request: Request, { params }: Params) {
-  const log = await prisma.habitLog.findUnique({ where: { id: params.id } });
+  const { id } = await params;
+  const log = await prisma.habitLog.findUnique({ where: { id } });
   if (!log) {
     return NextResponse.json(null, { status: 404 });
   }
@@ -17,9 +18,10 @@ export async function GET(_request: Request, { params }: Params) {
 }
 
 export async function PUT(request: Request, { params }: Params) {
+  const { id } = await params;
   const { completed, journal, reasonForMiss } = await request.json();
   const log = await prisma.habitLog.update({
-    where: { id: params.id },
+    where: { id },
     data: { completed, journal, reasonForMiss },
   });
   return NextResponse.json({
@@ -29,7 +31,8 @@ export async function PUT(request: Request, { params }: Params) {
 }
 
 export async function DELETE(_request: Request, { params }: Params) {
-  await prisma.habitLog.delete({ where: { id: params.id } });
+  const { id } = await params;
+  await prisma.habitLog.delete({ where: { id } });
   return new NextResponse(null, { status: 204 });
 }
 

--- a/src/app/api/habits/[id]/route.ts
+++ b/src/app/api/habits/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 export async function PUT(request: Request, { params }: Params) {
-  const { id } = params;
+  const { id } = await params;
   const { name, category } = await request.json();
   const habit = await prisma.habit.update({
     where: { id },
@@ -16,7 +16,7 @@ export async function PUT(request: Request, { params }: Params) {
 }
 
 export async function DELETE(_request: Request, { params }: Params) {
-  const { id } = params;
+  const { id } = await params;
   await prisma.habit.delete({ where: { id } });
   return new NextResponse(null, { status: 204 });
 }

--- a/src/components/molecules/habit-logger.tsx
+++ b/src/components/molecules/habit-logger.tsx
@@ -15,6 +15,8 @@ import {
   DialogClose,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { ThumbsDown, ThumbsUp, CheckCircle2, XCircle, PencilLine, Loader2 } from 'lucide-react';
 
 type HabitLoggerProps = {
@@ -92,19 +94,33 @@ export default function HabitLogger({
         <Dialog open={dialogState.open && (dialogState.type === 'edit_journal' || dialogState.type === 'edit_reason')} onOpenChange={(open) => setDialogState(prev => ({ ...prev, open }))}>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>
-                {dialogState.type === 'edit_journal' ? 'Edit jurnalmu' : 'Edit alasanmu'}
-              </DialogTitle>
-              <DialogDescription>
-                {dialogState.type === 'edit_journal'
-                  ? 'Perbarui ceritamu tentang pencapaianmu hari ini.'
-                  : "Perbarui alasan mengapa kamu melewatkannya hari ini."}
-              </DialogDescription>
+              <DialogTitle>Edit log harian</DialogTitle>
+              <DialogDescription>Perbarui status dan catatan hari ini.</DialogDescription>
             </DialogHeader>
+            <RadioGroup
+              value={dialogState.type as 'edit_journal' | 'edit_reason'}
+              onValueChange={(value) =>
+                setDialogState((prev) => ({ ...prev, type: value as 'edit_journal' | 'edit_reason', text: '' }))
+              }
+              className="flex gap-4 mb-4"
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="edit_journal" id="edit-completed" />
+                <Label htmlFor="edit-completed">Selesai</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="edit_reason" id="edit-missed" />
+                <Label htmlFor="edit-missed">Terlewat</Label>
+              </div>
+            </RadioGroup>
             <Textarea
               value={dialogState.text}
               onChange={(e) => setDialogState(prev => ({ ...prev, text: e.target.value }))}
-              placeholder="Tuliskan catatanmu di sini..."
+              placeholder={
+                dialogState.type === 'edit_journal'
+                  ? 'Tuliskan catatanmu di sini...'
+                  : 'Tuliskan alasanmu di sini...'
+              }
               rows={4}
             />
             <DialogFooter>


### PR DESCRIPTION
## Summary
- enable switching between Selesai and Terlewat when editing log notes in reports
- fix dynamic API routes to await params in habit and habit log handlers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive eslint prompt)
- `npm run typecheck` (fails: HabitLogWhereUniqueInput type error)


------
https://chatgpt.com/codex/tasks/task_b_68b15533f0fc8325b01825f9e6cd9445